### PR TITLE
kernel: Add prebuilt m4 to build environment

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -146,6 +146,7 @@ KERNEL_MAKE_FLAGS += HOSTCXX=$(CLANG_PREBUILTS)/bin/clang++
 # Since Linux 4.16, flex and bison are required
 KERNEL_MAKE_FLAGS += LEX=$(BUILD_TOP)/prebuilts/build-tools/$(HOST_OS)-x86/bin/flex
 KERNEL_MAKE_FLAGS += YACC=$(BUILD_TOP)/prebuilts/build-tools/$(HOST_OS)-x86/bin/bison
+KERNEL_MAKE_FLAGS += M4=$(BUILD_TOP)/prebuilts/build-tools/$(HOST_PREBUILT_TAG)/bin/m4
 TOOLS_PATH_OVERRIDE += BISON_PKGDATADIR=$(BUILD_TOP)/prebuilts/build-tools/common/bison
 
 # Set the out dir for the kernel's O= arg


### PR DESCRIPTION
 * android-11 removed M4 from the Allowed list, and provided a
   prebuilt binary in prebuilts/build-tools

Change-Id: I83d033ecd35a0e2318210e47309fcc010843347f
Signed-off-by: AlexThundrous <alexthundrous2104@gmail.com>