### PR TITLE
Fix digest for use in TWRP

### DIFF
--- a/build/tasks/bacon.mk
+++ b/build/tasks/bacon.mk
@@ -20,13 +20,13 @@ ifneq ($(BUILD_WITH_COLORS),0)
     include $(TOP_DIR)vendor/bootleggers/build/core/colors.mk
 endif
 
-MD5 := prebuilts/build-tools/path/$(HOST_PREBUILT_TAG)/md5sum
+SHA256 := prebuilts/build-tools/path/$(HOST_PREBUILT_TAG)/sha256sum
 BOOTLEGGERS_TARGET_PACKAGE := $(PRODUCT_OUT)/$(BOOTLEGGERS_VERSION).zip
 
 .PHONY: bacon bootleg bootleggers
 bacon: $(INTERNAL_OTA_PACKAGE_TARGET)
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(BOOTLEGGERS_TARGET_PACKAGE)
-	$(hide) $(MD5) $(BOOTLEGGERS_TARGET_PACKAGE) | sed "s|$(PRODUCT_OUT)/||"  > $(BOOTLEGGERS_TARGET_PACKAGE).md5sum
+	$(hide) $(SHA256) $(BOOTLEGGERS_TARGET_PACKAGE) | sed "s|$(PRODUCT_OUT)/||" > $(BOOTLEGGERS_TARGET_PACKAGE).sha256
 	@echo -e ${CL_CYN}""${CL_CYN}
 	@echo -e ${CL_CYN}"        ▄ █ "${CL_CYN}${CL_BLU}"███████▄▄      ▐██████████████     ████                ▄▄███████▀▄"${CL_BLU}
 	@echo -e ${CL_CYN}" ████████ █ "${CL_CYN}${CL_BLU}"██████████▄    ▐██████████████▌    ████             ▄██████████████"${CL_BLU}

--- a/build/tasks/bacon.mk
+++ b/build/tasks/bacon.mk
@@ -26,7 +26,7 @@ BOOTLEGGERS_TARGET_PACKAGE := $(PRODUCT_OUT)/$(BOOTLEGGERS_VERSION).zip
 .PHONY: bacon bootleg bootleggers
 bacon: $(INTERNAL_OTA_PACKAGE_TARGET)
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(BOOTLEGGERS_TARGET_PACKAGE)
-	$(hide) $(MD5) $(BOOTLEGGERS_TARGET_PACKAGE) > $(BOOTLEGGERS_TARGET_PACKAGE).md5sum
+	$(hide) $(MD5) $(BOOTLEGGERS_TARGET_PACKAGE) | sed "s|$(PRODUCT_OUT)/||"  > $(BOOTLEGGERS_TARGET_PACKAGE).md5sum
 	@echo -e ${CL_CYN}""${CL_CYN}
 	@echo -e ${CL_CYN}"        ▄ █ "${CL_CYN}${CL_BLU}"███████▄▄      ▐██████████████     ████                ▄▄███████▀▄"${CL_BLU}
 	@echo -e ${CL_CYN}" ████████ █ "${CL_CYN}${CL_BLU}"██████████▄    ▐██████████████▌    ████             ▄██████████████"${CL_BLU}

--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -6,7 +6,7 @@
 export C=/tmp/backupdir
 export SYSDEV="$(readlink -nf "$2")"
 export SYSFS="$3"
-export V=12
+export V=13
 
 export ADDOND_VERSION=1
 

--- a/prebuilt/common/bin/backuptool_ab.functions
+++ b/prebuilt/common/bin/backuptool_ab.functions
@@ -5,7 +5,7 @@
 
 export S=/system
 export C=/postinstall/tmp/backupdir
-export V=12
+export V=13
 export backuptool_ab=true
 
 copy_file() {

--- a/prebuilt/common/bin/backuptool_ab.sh
+++ b/prebuilt/common/bin/backuptool_ab.sh
@@ -5,7 +5,7 @@
 
 export S=/system
 export C=/postinstall/tmp/backupdir
-export V=12
+export V=13
 
 export ADDOND_VERSION=3
 


### PR DESCRIPTION
The first commit is needed, because the entire path in the digest-file breaks digest-checking in TWRP.
The second one is just a move to sha256 from md5, because it's more secure, but not necessarily needed.